### PR TITLE
Handle stream_end events

### DIFF
--- a/web/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/web/src/components/Layout/Sidebar/Sidebar.tsx
@@ -109,6 +109,14 @@ export function Sidebar({ isCollapsed, onToggleCollapse }: SidebarProps) {
     }
   }, []);
 
+  useEffect(() => {
+    const handler = () => {
+      loadReports();
+    };
+    window.addEventListener("report_saved", handler);
+    return () => window.removeEventListener("report_saved", handler);
+  }, []);
+
   const loadReports = async () => {
     setIsLoadingReports(true);
     try {

--- a/web/src/core/api/types.ts
+++ b/web/src/core/api/types.ts
@@ -75,9 +75,19 @@ export interface InterruptEvent
     }
   > {}
 
+export interface StreamEndEvent {
+  type: "stream_end";
+  data: {
+    thread_id: string;
+    finish_reason: string;
+    report_id?: string;
+  };
+}
+
 export type ChatEvent =
   | MessageChunkEvent
   | ToolCallsEvent
   | ToolCallChunksEvent
   | ToolCallResultEvent
-  | InterruptEvent;
+  | InterruptEvent
+  | StreamEndEvent;

--- a/web/src/core/store/store.ts
+++ b/web/src/core/store/store.ts
@@ -213,6 +213,15 @@ export async function sendMessage(
   try {
     for await (const event of stream) {
       const { type, data } = event;
+      if (type === "stream_end") {
+        if (data.report_id) {
+          window.dispatchEvent(
+            new CustomEvent("report_saved", { detail: data.report_id }),
+          );
+          toast.success("Report saved");
+        }
+        break;
+      }
       messageId = data.id;
       let message: Message | undefined;
       if (type === "tool_call_result") {


### PR DESCRIPTION
## Summary
- extend chat events with `StreamEndEvent`
- notify on stream_end during sendMessage
- refresh report list in Sidebar when report is saved

## Testing
- `make lint` *(fails: would reformat several files)*

------
https://chatgpt.com/codex/tasks/task_e_683fb65e2cf88324b75046a57d9213e8