### PR TITLE
Add simple chat mode alongside research mode

### DIFF
--- a/src/chat/graph/builder.py
+++ b/src/chat/graph/builder.py
@@ -1,0 +1,11 @@
+from langchain.chains import ConversationChain
+from langchain.memory import ConversationBufferMemory
+
+from src.llms.llm import get_llm_by_type
+
+
+def build_chat_graph_with_memory() -> ConversationChain:
+    """Return a simple conversation chain with memory."""
+    llm = get_llm_by_type("basic")
+    memory = ConversationBufferMemory(return_messages=True)
+    return ConversationChain(llm=llm, memory=memory)

--- a/src/db/db_session.py
+++ b/src/db/db_session.py
@@ -32,3 +32,29 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+from sqlalchemy.orm import Session
+from src.db_models import ChatSession, ChatMessage
+
+
+def get_or_create_chat_session(db: Session, thread_id: str) -> ChatSession:
+    session_obj = (
+        db.query(ChatSession).filter(ChatSession.thread_id == thread_id).first()
+    )
+    if session_obj is None:
+        session_obj = ChatSession(thread_id=thread_id)
+        db.add(session_obj)
+        db.commit()
+        db.refresh(session_obj)
+    return session_obj
+
+
+def add_chat_message(
+    db: Session, session_id: str, role: str, content: str
+) -> ChatMessage:
+    message = ChatMessage(session_id=session_id, role=role, content=content)
+    db.add(message)
+    db.commit()
+    db.refresh(message)
+    return message

--- a/src/db_models/__init__.py
+++ b/src/db_models/__init__.py
@@ -1,0 +1,5 @@
+from .users import User
+from .chat_session import ChatSession
+from .chat_message import ChatMessage
+
+__all__ = ["User", "ChatSession", "ChatMessage"]

--- a/src/db_models/chat_message.py
+++ b/src/db_models/chat_message.py
@@ -1,0 +1,20 @@
+from sqlalchemy import Column, ForeignKey, String, Text, TIMESTAMP, func
+from sqlalchemy_utils import UUIDType
+import uuid
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class ChatMessage(Base):
+    __tablename__ = "chat_messages"
+
+    id = Column(UUIDType(binary=False), primary_key=True, default=uuid.uuid4)
+    session_id = Column(
+        UUIDType(binary=False), ForeignKey("chat_sessions.id"), nullable=False
+    )
+    role = Column(String(32), nullable=False)
+    content = Column(Text, nullable=False)
+    created_at = Column(TIMESTAMP, server_default=func.current_timestamp())
+
+    session = relationship("ChatSession", back_populates="messages")

--- a/src/db_models/chat_session.py
+++ b/src/db_models/chat_session.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, String, TIMESTAMP, func
+from sqlalchemy_utils import UUIDType
+import uuid
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class ChatSession(Base):
+    __tablename__ = "chat_sessions"
+
+    id = Column(UUIDType(binary=False), primary_key=True, default=uuid.uuid4)
+    thread_id = Column(String(255), unique=True, nullable=False)
+    created_at = Column(TIMESTAMP, server_default=func.current_timestamp())
+
+    messages = relationship(
+        "ChatMessage", back_populates="session", cascade="all, delete-orphan"
+    )

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -8,13 +8,19 @@ import os
 from typing import List, cast
 from uuid import uuid4
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response, StreamingResponse
 from langchain_core.messages import AIMessageChunk, ToolMessage
 from langgraph.types import Command
 
 from src.graph.builder import build_graph_with_memory
+from src.chat.graph.builder import build_chat_graph_with_memory
+from src.db.db_session import (
+    get_db,
+    get_or_create_chat_session,
+    add_chat_message,
+)
 from src.podcast.graph.builder import build_graph as build_podcast_graph
 from src.ppt.graph.builder import build_graph as build_ppt_graph
 from src.prose.graph.builder import build_graph as build_prose_graph
@@ -30,7 +36,7 @@ from src.server.mcp_request import MCPServerMetadataRequest, MCPServerMetadataRe
 from src.server.mcp_utils import load_mcp_tools
 from src.tools import VolcengineTTS
 
-#Routes from API folders
+# Routes from API folders
 from src.api.api_register_user import router as register_user_router
 from src.api.api_generate_token import user_generate_token_router
 from src.api.api_get_current_user import current_user_router
@@ -58,6 +64,7 @@ app.add_middleware(
 )
 
 graph = build_graph_with_memory()
+simple_chats: dict[str, any] = {}
 
 
 @app.post("/api/chat/stream")
@@ -175,6 +182,36 @@ def _make_event(event_type: str, data: dict[str, any]):
     if data.get("content") == "":
         data.pop("content")
     return f"event: {event_type}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
+
+
+@app.post("/api/chat/simple")
+async def chat_simple(request: ChatRequest, db=Depends(get_db)):
+    thread_id = request.thread_id
+    if thread_id == "__default__":
+        thread_id = str(uuid4())
+
+    chain = simple_chats.get(thread_id)
+    if chain is None:
+        chain = build_chat_graph_with_memory()
+        simple_chats[thread_id] = chain
+
+    user_msg = request.messages[-1].content if request.messages else ""
+    response = chain.invoke(user_msg)
+
+    session_obj = get_or_create_chat_session(db, thread_id)
+    add_chat_message(db, session_obj.id, "user", user_msg)
+    add_chat_message(db, session_obj.id, "assistant", response)
+
+    async def gen():
+        event = {
+            "thread_id": thread_id,
+            "id": str(uuid4()),
+            "role": "assistant",
+            "content": response,
+        }
+        yield _make_event("message_chunk", event)
+
+    return StreamingResponse(gen(), media_type="text/event-stream")
 
 
 @app.post("/api/tts")

--- a/web/src/app/chat/components/input-box.tsx
+++ b/web/src/app/chat/components/input-box.tsx
@@ -18,6 +18,7 @@ import type { Option } from "~/core/messages";
 import {
   setEnableBackgroundInvestigation,
   useSettingsStore,
+  useStore,
 } from "~/core/store";
 import { cn } from "~/lib/utils";
 
@@ -34,7 +35,10 @@ export function InputBox({
   size?: "large" | "normal";
   responding?: boolean;
   feedback?: { option: Option } | null;
-  onSend?: (message: string, options?: { interruptFeedback?: string }) => void;
+  onSend?: (
+    message: string,
+    options?: { interruptFeedback?: string; mode?: "chat" | "research" },
+  ) => void;
   onCancel?: () => void;
   onRemoveFeedback?: () => void;
 }) {
@@ -44,6 +48,8 @@ export function InputBox({
   const backgroundInvestigation = useSettingsStore(
     (state) => state.general.enableBackgroundInvestigation,
   );
+  const mode = useStore((state) => state.mode);
+  const setMode = useStore((state) => state.setMode);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const feedbackRef = useRef<HTMLDivElement>(null);
 
@@ -72,12 +78,13 @@ export function InputBox({
       if (onSend) {
         onSend(message, {
           interruptFeedback: feedback?.option.value,
+          mode,
         });
         setMessage("");
         onRemoveFeedback?.();
       }
     }
-  }, [responding, onCancel, message, onSend, feedback, onRemoveFeedback]);
+  }, [responding, onCancel, message, onSend, feedback, onRemoveFeedback, mode]);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -173,8 +180,16 @@ export function InputBox({
             >
               <Detective /> Investigation
             </Button>
-          </Tooltip>
-        </div>
+        </Tooltip>
+        <select
+          className="ml-2 rounded-2xl border px-2 py-1 text-sm"
+          value={mode}
+          onChange={(e) => setMode(e.target.value as "chat" | "research")}
+        >
+          <option value="research">Research</option>
+          <option value="chat">Chat</option>
+        </select>
+      </div>
         <div className="flex shrink-0 items-center gap-2">
           <Tooltip title={responding ? "Stop" : "Send"}>
             <Button

--- a/web/src/app/chat/components/messages-block.tsx
+++ b/web/src/app/chat/components/messages-block.tsx
@@ -36,7 +36,10 @@ export function MessagesBlock({ className }: { className?: string }) {
   const abortControllerRef = useRef<AbortController | null>(null);
   const [feedback, setFeedback] = useState<{ option: Option } | null>(null);
   const handleSend = useCallback(
-    async (message: string, options?: { interruptFeedback?: string }) => {
+    async (
+      message: string,
+      options?: { interruptFeedback?: string; mode?: "chat" | "research" },
+    ) => {
       const abortController = new AbortController();
       abortControllerRef.current = abortController;
       try {
@@ -48,6 +51,7 @@ export function MessagesBlock({ className }: { className?: string }) {
           },
           {
             abortSignal: abortController.signal,
+            mode: options?.mode,
           },
         );
       } catch {}

--- a/web/src/core/api/chat.ts
+++ b/web/src/core/api/chat.ts
@@ -11,6 +11,23 @@ import { sleep } from "../utils";
 import { resolveServiceURL } from "./resolve-service-url";
 import type { ChatEvent } from "./types";
 
+export async function* chatSimpleStream(
+  userMessage: string,
+  params: { thread_id: string },
+  options: { abortSignal?: AbortSignal } = {},
+) {
+  const stream = fetchStream(resolveServiceURL("chat/simple"), {
+    body: JSON.stringify({ messages: [{ role: "user", content: userMessage }], ...params }),
+    signal: options.abortSignal,
+  });
+  for await (const event of stream) {
+    yield {
+      type: event.event,
+      data: JSON.parse(event.data),
+    } as ChatEvent;
+  }
+}
+
 export async function* chatStream(
   userMessage: string,
   params: {

--- a/web/src/core/store/store.ts
+++ b/web/src/core/store/store.ts
@@ -6,7 +6,7 @@ import { toast } from "sonner";
 import { create } from "zustand";
 import { useShallow } from "zustand/react/shallow";
 
-import { chatStream, generatePodcast } from "../api";
+import { chatStream, chatSimpleStream, generatePodcast } from "../api";
 import type { Message } from "../messages";
 import { mergeMessage } from "../messages";
 import { parseJSON } from "../utils";
@@ -17,6 +17,7 @@ const THREAD_ID = nanoid();
 
 export const useStore = create<{
   responding: boolean;
+  mode: "chat" | "research";
   threadId: string | undefined;
   messageIds: string[];
   messages: Map<string, Message>;
@@ -26,6 +27,7 @@ export const useStore = create<{
   researchActivityIds: Map<string, string[]>;
   ongoingResearchId: string | null;
   openResearchId: string | null;
+  mode: "chat" | "research";
 
   appendMessage: (message: Message) => void;
   updateMessage: (message: Message) => void;
@@ -33,6 +35,7 @@ export const useStore = create<{
   openResearch: (researchId: string | null) => void;
   closeResearch: () => void;
   setOngoingResearch: (researchId: string | null) => void;
+  setMode: (mode: "chat" | "research") => void;
 }>((set) => ({
   responding: false,
   threadId: THREAD_ID,
@@ -44,6 +47,7 @@ export const useStore = create<{
   researchActivityIds: new Map<string, string[]>(),
   ongoingResearchId: null,
   openResearchId: null,
+  mode: "research",
 
   appendMessage(message: Message) {
     set((state) => ({
@@ -72,6 +76,9 @@ export const useStore = create<{
   setOngoingResearch(researchId: string | null) {
     set({ ongoingResearchId: researchId });
   },
+  setMode(mode: "chat" | "research") {
+    set({ mode });
+  },
 }));
 
 export async function sendMessage(
@@ -81,7 +88,7 @@ export async function sendMessage(
   }: {
     interruptFeedback?: string;
   } = {},
-  options: { abortSignal?: AbortSignal } = {},
+  options: { abortSignal?: AbortSignal; mode?: "chat" | "research" } = {},
 ) {
   if (content != null) {
     appendMessage({
@@ -94,20 +101,30 @@ export async function sendMessage(
   }
 
   const settings = getChatStreamSettings();
-  const stream = chatStream(
-    content ?? "[REPLAY]",
-    {
-      thread_id: THREAD_ID,
-      interrupt_feedback: interruptFeedback,
-      auto_accepted_plan: settings.autoAcceptedPlan,
-      enable_background_investigation:
-        settings.enableBackgroundInvestigation ?? true,
-      max_plan_iterations: settings.maxPlanIterations,
-      max_step_num: settings.maxStepNum,
-      mcp_settings: settings.mcpSettings,
-    },
-    options,
-  );
+  const mode = options.mode ?? useStore.getState().mode;
+  const stream =
+    mode === "research"
+      ? chatStream(
+          content ?? "[REPLAY]",
+          {
+            thread_id: THREAD_ID,
+            interrupt_feedback: interruptFeedback,
+            auto_accepted_plan: settings.autoAcceptedPlan,
+            enable_background_investigation:
+              settings.enableBackgroundInvestigation ?? true,
+            max_plan_iterations: settings.maxPlanIterations,
+            max_step_num: settings.maxStepNum,
+            mcp_settings: settings.mcpSettings,
+          },
+          options,
+        )
+      : chatSimpleStream(
+          content ?? "",
+          {
+            thread_id: THREAD_ID,
+          },
+          options,
+        );
 
   setResponding(true);
   let messageId: string | undefined;
@@ -376,4 +393,12 @@ export function useLastFeedbackMessageId() {
     }),
   );
   return waitingForFeedbackMessageId;
+}
+
+export function useMode() {
+  return useStore(useShallow((state) => state.mode));
+}
+
+export function setMode(value: "chat" | "research") {
+  useStore.getState().setMode(value);
 }


### PR DESCRIPTION
## Summary
- implement lightweight conversation workflow using LangChain with memory
- add database models and helpers for chat sessions and messages
- expose `/api/chat/simple` endpoint for simple chat
- support chat mode in the frontend store and UI
- allow selecting between Chat and Research modes in the input box
- switch API calls based on selected mode

## Testing
- `make format`
- `make lint`
- `make install-dev`
- `make test` *(fails: Value error TAVILY_API_KEY)*
- set dummy TAVILY_API_KEY and rerun `make test`

------
https://chatgpt.com/codex/tasks/task_e_6840d758b5448324836616eab624c8a6