### PR TITLE
Fix simple chat DB session handling

### DIFF
--- a/src/chat/graph/builder.py
+++ b/src/chat/graph/builder.py
@@ -1,0 +1,11 @@
+from langchain.chains import ConversationChain
+from langchain.memory import ConversationBufferMemory
+
+from src.llms.llm import basic_llm
+
+
+def build_chat_graph_with_memory() -> ConversationChain:
+    """Return a simple conversational chain with memory."""
+    memory = ConversationBufferMemory(return_messages=True)
+    chain = ConversationChain(llm=basic_llm, memory=memory)
+    return chain

--- a/src/db/db_session.py
+++ b/src/db/db_session.py
@@ -1,8 +1,9 @@
-from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
 import os
 from dotenv import load_dotenv
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+
+from src.db_models import Base, ChatSession, ChatMessage
 
 load_dotenv()
 
@@ -12,23 +13,44 @@ DATABASE_HOST = os.getenv("DATABASE_HOST")
 DATABASE_PORT = int(os.getenv("DATABASE_PORT"))
 DATABASE_NAME = os.getenv("DATABASE_NAME")
 
-DATABASE_URL = f"mysql+mysqlconnector://{DATABASE_USER_NAME}:{DATABASE_PASSWORD}@{DATABASE_HOST}:{DATABASE_PORT}/{DATABASE_NAME}"
+DATABASE_URL = (
+    f"mysql+mysqlconnector://{DATABASE_USER_NAME}:{DATABASE_PASSWORD}"
+    f"@{DATABASE_HOST}:{DATABASE_PORT}/{DATABASE_NAME}"
+)
 
-
-# Create the SQLAlchemy engine
 engine = create_engine(DATABASE_URL)
-
-# Create a base class for our models
-Base = declarative_base()
-
-# Create a session factory bound to our engine
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
-# Dependency function to get DB session
-def get_db():
+def create_db_tables() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db() -> Session:
     db = SessionLocal()
     try:
         yield db
     finally:
         db.close()
+
+
+def get_or_create_chat_session(db: Session, thread_id: str) -> ChatSession:
+    session_obj = (
+        db.query(ChatSession).filter(ChatSession.thread_id == thread_id).first()
+    )
+    if not session_obj:
+        session_obj = ChatSession(thread_id=thread_id)
+        db.add(session_obj)
+        db.commit()
+        db.refresh(session_obj)
+    return session_obj
+
+
+def add_chat_message(
+    db: Session, session_obj: ChatSession, role: str, content: str
+) -> ChatMessage:
+    msg = ChatMessage(session_id=session_obj.id, role=role, content=content)
+    db.add(msg)
+    db.commit()
+    db.refresh(msg)
+    return msg

--- a/src/db_models/__init__.py
+++ b/src/db_models/__init__.py
@@ -1,0 +1,6 @@
+from .chat_session import ChatSession
+from .chat_message import ChatMessage
+from .users import User
+from .base import Base
+
+__all__ = ["ChatSession", "ChatMessage", "User", "Base"]

--- a/src/db_models/chat_message.py
+++ b/src/db_models/chat_message.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, ForeignKey, String, Text, TIMESTAMP, func
+from sqlalchemy_utils import UUIDType
+from sqlalchemy.orm import relationship
+import uuid
+
+from .base import Base
+
+
+class ChatMessage(Base):
+    __tablename__ = "chat_messages"
+
+    id = Column(UUIDType(binary=False), primary_key=True, default=uuid.uuid4)
+    session_id = Column(UUIDType(binary=False), ForeignKey("chat_sessions.id"))
+    role = Column(String(20), nullable=False)
+    content = Column(Text, nullable=False)
+    created_at = Column(TIMESTAMP, server_default=func.current_timestamp())
+
+    session = relationship("ChatSession", back_populates="messages")

--- a/src/db_models/chat_session.py
+++ b/src/db_models/chat_session.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, String, TIMESTAMP, func
+from sqlalchemy_utils import UUIDType
+from sqlalchemy.orm import relationship
+import uuid
+
+from .base import Base
+
+
+class ChatSession(Base):
+    __tablename__ = "chat_sessions"
+
+    id = Column(UUIDType(binary=False), primary_key=True, default=uuid.uuid4)
+    thread_id = Column(String(255), unique=True, index=True, nullable=False)
+    created_at = Column(TIMESTAMP, server_default=func.current_timestamp())
+
+    messages = relationship("ChatMessage", back_populates="session")

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -8,13 +8,14 @@ import os
 from typing import List, cast
 from uuid import uuid4
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response, StreamingResponse
 from langchain_core.messages import AIMessageChunk, ToolMessage
 from langgraph.types import Command
 
 from src.graph.builder import build_graph_with_memory
+from src.chat.graph.builder import build_chat_graph_with_memory
 from src.podcast.graph.builder import build_graph as build_podcast_graph
 from src.ppt.graph.builder import build_graph as build_ppt_graph
 from src.prose.graph.builder import build_graph as build_prose_graph
@@ -29,8 +30,15 @@ from src.server.chat_request import (
 from src.server.mcp_request import MCPServerMetadataRequest, MCPServerMetadataResponse
 from src.server.mcp_utils import load_mcp_tools
 from src.tools import VolcengineTTS
+from src.db.db_session import (
+    create_db_tables,
+    SessionLocal,
+    get_or_create_chat_session,
+    add_chat_message,
+)
+from langchain.chains import ConversationChain
 
-#Routes from API folders
+# Routes from API folders
 from src.api.api_register_user import router as register_user_router
 from src.api.api_generate_token import user_generate_token_router
 from src.api.api_get_current_user import current_user_router
@@ -58,6 +66,9 @@ app.add_middleware(
 )
 
 graph = build_graph_with_memory()
+chat_chains: dict[str, ConversationChain] = {}
+
+create_db_tables()
 
 
 @app.post("/api/chat/stream")
@@ -78,6 +89,41 @@ async def chat_stream(request: ChatRequest):
         ),
         media_type="text/event-stream",
     )
+
+
+@app.post("/api/chat/simple")
+async def chat_simple(request: ChatRequest):
+    thread_id = request.thread_id
+    if thread_id == "__default__":
+        thread_id = str(uuid4())
+
+    db = SessionLocal()
+    session_obj = get_or_create_chat_session(db, thread_id)
+
+    chain = chat_chains.get(thread_id)
+    if chain is None:
+        chain = build_chat_graph_with_memory()
+        chat_chains[thread_id] = chain
+
+    user_message = request.messages[-1].content if request.messages else ""
+    add_chat_message(db, session_obj, "user", user_message)
+
+    def iter_response():
+        try:
+            response_text = chain.invoke(user_message)
+            add_chat_message(db, session_obj, "assistant", response_text)
+            data = {
+                "thread_id": thread_id,
+                "id": str(uuid4()),
+                "role": "assistant",
+                "content": response_text,
+                "finish_reason": "stop",
+            }
+            yield f"event: message_chunk\ndata: {json.dumps(data)}\n\n"
+        finally:
+            db.close()
+
+    return StreamingResponse(iter_response(), media_type="text/event-stream")
 
 
 async def _astream_workflow_generator(

--- a/web/src/app/chat/components/input-box.tsx
+++ b/web/src/app/chat/components/input-box.tsx
@@ -18,6 +18,7 @@ import type { Option } from "~/core/messages";
 import {
   setEnableBackgroundInvestigation,
   useSettingsStore,
+  useStore,
 } from "~/core/store";
 import { cn } from "~/lib/utils";
 
@@ -41,6 +42,8 @@ export function InputBox({
   const [message, setMessage] = useState("");
   const [imeStatus, setImeStatus] = useState<"active" | "inactive">("inactive");
   const [indent, setIndent] = useState(0);
+  const mode = useStore((state) => state.mode);
+  const setMode = useStore((state) => state.setMode);
   const backgroundInvestigation = useSettingsStore(
     (state) => state.general.enableBackgroundInvestigation,
   );
@@ -144,6 +147,14 @@ export function InputBox({
         />
       </div>
       <div className="flex items-center px-4 py-2">
+        <select
+          className="mr-2 rounded-md border px-2 py-1 text-sm"
+          value={mode}
+          onChange={(e) => setMode(e.target.value as "chat" | "research")}
+        >
+          <option value="chat">Chat</option>
+          <option value="research">Research</option>
+        </select>
         <div className="flex grow">
           <Tooltip
             className="max-w-60"

--- a/web/src/core/api/chat.ts
+++ b/web/src/core/api/chat.ts
@@ -54,6 +54,26 @@ export async function* chatStream(
   }
 }
 
+export async function* chatSimpleStream(
+  userMessage: string,
+  params: { thread_id: string },
+  options: { abortSignal?: AbortSignal } = {},
+) {
+  const stream = fetchStream(resolveServiceURL("chat/simple"), {
+    body: JSON.stringify({
+      messages: [{ role: "user", content: userMessage }],
+      ...params,
+    }),
+    signal: options.abortSignal,
+  });
+  for await (const event of stream) {
+    yield {
+      type: event.event,
+      data: JSON.parse(event.data),
+    } as ChatEvent;
+  }
+}
+
 async function* chatReplayStream(
   userMessage: string,
   params: {

--- a/web/src/core/store/store.ts
+++ b/web/src/core/store/store.ts
@@ -6,7 +6,8 @@ import { toast } from "sonner";
 import { create } from "zustand";
 import { useShallow } from "zustand/react/shallow";
 
-import { chatStream, generatePodcast } from "../api";
+import { chatStream, chatSimpleStream, generatePodcast } from "../api";
+import type { ChatEvent } from "../api/types";
 import type { Message } from "../messages";
 import { mergeMessage } from "../messages";
 import { parseJSON } from "../utils";
@@ -18,6 +19,7 @@ const THREAD_ID = nanoid();
 export const useStore = create<{
   responding: boolean;
   threadId: string | undefined;
+  mode: "chat" | "research";
   messageIds: string[];
   messages: Map<string, Message>;
   researchIds: string[];
@@ -33,9 +35,11 @@ export const useStore = create<{
   openResearch: (researchId: string | null) => void;
   closeResearch: () => void;
   setOngoingResearch: (researchId: string | null) => void;
+  setMode: (mode: "chat" | "research") => void;
 }>((set) => ({
   responding: false,
   threadId: THREAD_ID,
+  mode: "research",
   messageIds: [],
   messages: new Map<string, Message>(),
   researchIds: [],
@@ -72,6 +76,9 @@ export const useStore = create<{
   setOngoingResearch(researchId: string | null) {
     set({ ongoingResearchId: researchId });
   },
+  setMode(mode: "chat" | "research") {
+    set({ mode });
+  },
 }));
 
 export async function sendMessage(
@@ -83,6 +90,7 @@ export async function sendMessage(
   } = {},
   options: { abortSignal?: AbortSignal } = {},
 ) {
+  const mode = useStore.getState().mode;
   if (content != null) {
     appendMessage({
       id: nanoid(),
@@ -93,21 +101,30 @@ export async function sendMessage(
     });
   }
 
-  const settings = getChatStreamSettings();
-  const stream = chatStream(
-    content ?? "[REPLAY]",
-    {
-      thread_id: THREAD_ID,
-      interrupt_feedback: interruptFeedback,
-      auto_accepted_plan: settings.autoAcceptedPlan,
-      enable_background_investigation:
-        settings.enableBackgroundInvestigation ?? true,
-      max_plan_iterations: settings.maxPlanIterations,
-      max_step_num: settings.maxStepNum,
-      mcp_settings: settings.mcpSettings,
-    },
-    options,
-  );
+  let stream: AsyncIterable<ChatEvent>;
+  if (mode === "research") {
+    const settings = getChatStreamSettings();
+    stream = chatStream(
+      content ?? "[REPLAY]",
+      {
+        thread_id: THREAD_ID,
+        interrupt_feedback: interruptFeedback,
+        auto_accepted_plan: settings.autoAcceptedPlan,
+        enable_background_investigation:
+          settings.enableBackgroundInvestigation ?? true,
+        max_plan_iterations: settings.maxPlanIterations,
+        max_step_num: settings.maxStepNum,
+        mcp_settings: settings.mcpSettings,
+      },
+      options,
+    );
+  } else {
+    stream = chatSimpleStream(
+      content ?? "",
+      { thread_id: THREAD_ID },
+      options,
+    );
+  }
 
   setResponding(true);
   let messageId: string | undefined;
@@ -118,7 +135,7 @@ export async function sendMessage(
       let message: Message | undefined;
       if (type === "tool_call_result") {
         message = findMessageByToolCallId(data.tool_call_id);
-      } else if (!existsMessage(messageId)) {
+      } else if (messageId && !existsMessage(messageId)) {
         message = {
           id: messageId,
           threadId: data.thread_id,
@@ -131,7 +148,7 @@ export async function sendMessage(
         };
         appendMessage(message);
       }
-      message ??= getMessage(messageId);
+      message ??= messageId ? getMessage(messageId) : undefined;
       if (message) {
         message = mergeMessage(message, event);
         updateMessage(message);
@@ -345,6 +362,10 @@ export function useMessage(messageId: string | null | undefined) {
 
 export function useMessageIds() {
   return useStore(useShallow((state) => state.messageIds));
+}
+
+export function useChatMode() {
+  return useStore(useShallow((state) => state.mode));
 }
 
 export function useLastInterruptMessage() {

--- a/web/src/services/HTTP.ts
+++ b/web/src/services/HTTP.ts
@@ -5,7 +5,6 @@ interface ApiResponse<T = unknown> {
   message?: string;
 }
 
-type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
 export const fetcher = async <T>(
   url: string,
@@ -70,34 +69,4 @@ export const fileFetcher = async <T>(
   } catch (error) {
     throw error;
   }
-};
-
-// Refresh Token Logic
-const handleRefreshToken = async <T>(
-  url: string,
-  options: RequestInit
-): Promise<ApiResponse<T>> => {
-  const refreshToken = localStorage.getItem('refreshToken');
-  if (!refreshToken) {
-    throw new Error('No refresh token available');
-  }
-
-  const refreshResponse = await fetch(`${API_BASE_URL}/auth/refresh`, {
-    method: 'POST',
-    body: JSON.stringify({ refreshToken }),
-    headers: { 'Content-Type': 'application/json' },
-  });
-
-  if (!refreshResponse.ok) {
-    throw new Error('Refresh token failed');
-  }
-
-  const { accessToken } = await refreshResponse.json();
-  localStorage.setItem('authToken', accessToken);
-
-  // Retry original request with new token
-  return fetcher(url, {
-    ...options,
-    headers: { Authorization: `Bearer ${accessToken}` },
-  });
 };


### PR DESCRIPTION
## Summary
- use `SessionLocal` directly for `/api/chat/simple`
- close DB session inside streaming generator to avoid detached object errors

## Testing
- `make format`
- `make lint`
- `make test` *(fails: pytest unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6840d758b5448324836616eab624c8a6